### PR TITLE
Improve trainer hotkeys and pipe connection handling

### DIFF
--- a/trainer/include/pipelogger.h
+++ b/trainer/include/pipelogger.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <Windows.h>
+#include <atomic>
 #include <string>
 
 // Named Pipe Logger - sends messages to the TUI loader
@@ -18,12 +19,14 @@ public:
     void SendInit(uintptr_t moduleBase, uintptr_t playerBase, const std::string& version, bool initialized);
     
     // Check if pipe is connected
-    bool IsConnected() const { return pipeHandle != INVALID_HANDLE_VALUE; }
-    
+    bool IsConnected() const { return connected.load() && pipeHandle != INVALID_HANDLE_VALUE; }
+
 private:
     HANDLE pipeHandle;
-    bool connected;
-    
+    std::atomic<bool> connected;
+
+    void BeginAcceptLoop();
+
     // Helper to send JSON message
     bool SendMessage(const std::string& json);
     

--- a/trainer/include/trainer.h
+++ b/trainer/include/trainer.h
@@ -17,13 +17,23 @@ private:
     bool godMode;
     bool infiniteAmmo;
     bool noRecoil;
-    
+
+    // Hotkey tracking
+    bool prevF1State;
+    bool prevF2State;
+    bool prevF3State;
+    bool prevF4State;
+    bool prevEndState;
+
     // Player addresses (to be found)
     uintptr_t playerBase;
     uintptr_t healthAddress;
     uintptr_t armorAddress;
     uintptr_t ammoAddress;
-    
+
+    // Pipe state tracking
+    bool lastPipeConnectionState;
+
     // Original bytes for patching/unpatching
     std::vector<BYTE> originalHealthBytes;
     std::vector<BYTE> originalAmmoBytes;
@@ -82,7 +92,7 @@ public:
     void SetHealth(int value);
     void SetArmor(int value);
     void SetAmmo(int value);
-    
+
     // Address finding
     bool FindPlayerBase();
     bool FindHealthAddress();
@@ -91,6 +101,7 @@ public:
     // Utility
     void UpdatePlayerData();
     void DisplayStatus();
+    void BroadcastStatus();
 };
 
 #endif // TRAINER_H


### PR DESCRIPTION
## Summary
- make the trainer pipe logger resilient by tracking connection state, restarting the accept loop, and reporting status updates when the trainer reconnects
- tighten host key handling with edge-triggered checks and broadcast updated trainer stats whenever features toggle
- update the TUI IPC client to use message mode and surface connection status/log-driven reconnection attempts in the assault cube loader view

## Testing
- go test ./... *(fails: build uses Windows-only APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68f267d9b460832ba59d05dbabf6e5c8