### PR TITLE
Fix AssaultCube no recoil feature

### DIFF
--- a/trainer/STATUS.md
+++ b/trainer/STATUS.md
@@ -6,7 +6,7 @@
 All addresses from `addresses.md` have been integrated into the trainer:
 
 **Static Addresses:**
-- LocalPlayer: `[ac_client.exe + 0x0017E0A8]`
+- LocalPlayer: `[ac_client.exe + 0x17B0B8]`
 - Entity List: `[ac_client.exe + 0x18AC04]`
 - FOV: `[ac_client.exe + 0x18A7CC]`
 - PlayerCount: `[ac_client.exe + 0x18AC0C]`

--- a/trainer/include/trainer.h
+++ b/trainer/include/trainer.h
@@ -129,7 +129,8 @@ public:
     // Utility
     void UpdatePlayerData();
     void DisplayStatus();
-    
+    void RefreshPlayerAddresses();
+
     // Build feature toggles for UI
     std::vector<FeatureToggle> BuildFeatureToggles();
     PlayerStats GetPlayerStats();


### PR DESCRIPTION
## Summary
- refresh the cached local player pointer and dependent offsets using the documented 0x17B0B8 base
- implement recoil pattern scanning, patching, and runtime zeroing so the no-recoil toggle actually works
- update the status documentation to reflect the corrected local player offset

## Testing
- not run (Windows-only components)

------
https://chatgpt.com/codex/tasks/task_e_68fbc19c505c832b829986ad73af5504